### PR TITLE
fix: adaptation framework,to change the name attribute arkTSTurboModuleInstanceRef

### DIFF
--- a/react-native-reanimated/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/react-native-reanimated/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -54,7 +54,7 @@ namespace rnoh {
             ArkJS arkJs(m_ctx.env);
             auto napiArgs = arkJs.convertIntermediaryValueToNapiValue(dynamic);
             auto napiTag = arkJs.createInt(tag);
-            auto napiTurboModuleObject = arkJs.getObject(m_ctx.arkTsTurboModuleInstanceRef);
+            auto napiTurboModuleObject = arkJs.getObject(m_ctx.arkTSTurboModuleInstanceRef);
             napiTurboModuleObject.call("setViewProps", {napiTag, napiArgs});
         };
         auto progressLayoutAnimation = [=](jsi::Runtime &rt, int tag, const jsi::Object &newStyle,


### PR DESCRIPTION

# Summary

-fix: adaptation framework,to change the name attribute arkTSTurboModuleInstanceRef
-Close: #2 

## Test Plan

编译运行3.6.1版本，这个属性arkTsTurboModuleInstanceRef需要改成arkTSTurboModuleInstanceRef

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
