### PR TITLE
fix:the component's onLayout does not call back

### DIFF
--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -173,6 +173,8 @@ void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
                 auto eventCopy = rawEvent;
                 eventCopy.type = "on" + eventType.substr(5);
                 return nativeReanimatedModule->handleRawEvent(eventCopy, frameTime);
+            } else if (eventType.rfind("topLayout", 0) == 0) { // 针对onLayout事件，不阻断，采用系统处理
+                return false;
             }
             return nativeReanimatedModule->handleRawEvent(rawEvent, frameTime);
         });


### PR DESCRIPTION
# Summary


- Close: #18 
- fix:the component's onLayout does not call back

## Test Plan

在js侧使用Animated.View等组件时候，给其注册onLayout回调方法，在程序运行时候，其回调不走

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.72.52-CAPI
- DevEco Studio: 5.0.3.300
- OH SDK: HarmonyOS NEXT Developer Canary3 SP2
- ROM: 3.0.0.22(Canary3)
