### PR TITLE
feat:新增react-native-reanimated动画库支持useAnimatedKeyboard属性

### DIFF
--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -35,6 +35,9 @@ ReanimatedModule::~ReanimatedModule() {
     if (eventListener) {
         m_ctx.scheduler->removeEventListener(eventListener);
     }
+    if (keyboardEventDataUpdater_) {
+        keyboardEventDataUpdater_ = nullptr;
+    }
 }
 
 void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
@@ -102,12 +105,38 @@ void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
         // TODO
     };
     auto subscribeForKeyboardEventsFunction =
-        [](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater, bool isStatusBarTranslucent) {
-            // TODO
+        [weakSelf = weak_from_this()](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater,
+                                      bool isStatusBarTranslucent) {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return 0;
+            }
+            self->keyboardEventDataUpdater_ = std::move(keyboardEventDataUpdater);
+            auto weakExecutor = std::weak_ptr(self->m_ctx.taskExecutor);
+            if (auto taskExecutor = weakExecutor.lock()) {
+                taskExecutor->runTask(TaskThread::MAIN, [ctx = self->m_ctx, isStatusBarTranslucent]() {
+                    ArkJS arkJs(ctx.env);
+                    // arkJs.createBoolean(isStatusBarTranslucent);
+                    auto napiTurboModuleObject = arkJs.getObject(ctx.arkTSTurboModuleInstanceRef);
+                    napiTurboModuleObject.call("subscribeKeyBordListeners", {});
+                });
+            }
             return 0;
         };
-    auto unsubscribeFromKeyboardEventsFunction = [](int listenerId) {
-        // TODO
+    auto unsubscribeFromKeyboardEventsFunction = [weakSelf = weak_from_this()](int listenerId) {
+        auto self = weakSelf.lock();
+        if (!self) {
+            return 0;
+        }
+        auto weakExecutor = std::weak_ptr(self->m_ctx.taskExecutor);
+        if (auto taskExecutor = weakExecutor.lock()) {
+            taskExecutor->runTask(TaskThread::MAIN, [ctx = self->m_ctx]() {
+                ArkJS arkJs(ctx.env);
+                auto napiTurboModuleObject = arkJs.getObject(ctx.arkTSTurboModuleInstanceRef);
+                napiTurboModuleObject.call("unsubscribeKeyBordListeners", {});
+            });
+        }
+        return 0;
     };
     auto setGestureStateFunction = [weakSelf = weak_from_this()](int handlerTag, int newState) {
         auto self = weakSelf.lock();
@@ -184,6 +213,12 @@ void ReanimatedModule::injectDependencies(facebook::jsi::Runtime & /*rt*/) {
     const auto uiManager = m_ctx.scheduler->getUIManager();
     if (auto nativeReanimatedModule = weakNativeReanimatedModule_.lock()) {
         nativeReanimatedModule->initializeFabric(uiManager);
+    }
+}
+
+void ReanimatedModule::callKeyBord(double height, int status) {
+    if (keyboardEventDataUpdater_) {
+        keyboardEventDataUpdater_(status, height);
     }
 }
 } // namespace rnoh

--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.h
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.h
@@ -11,11 +11,12 @@ public:
     ReanimatedModule(const ArkTSTurboModule::Context ctx, const std::string name);
     ~ReanimatedModule() override;
     void installTurboModule(facebook::jsi::Runtime &rt);
-
+    void callKeyBord(double height, int status);
 private:
     std::weak_ptr<reanimated::NativeReanimatedModule> weakNativeReanimatedModule_;
     void injectDependencies(facebook::jsi::Runtime &rt);
     std::shared_ptr<facebook::react::EventListener> eventListener;
+    std::function<void(int keyboardState, int height)> keyboardEventDataUpdater_;
 };
 
 } // namespace rnoh

--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedPackage.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedPackage.cpp
@@ -17,3 +17,20 @@ public:
 std::unique_ptr<TurboModuleFactoryDelegate> ReanimatedPackage::createTurboModuleFactoryDelegate() {
     return std::make_unique<ReanimatedTurboModuleFactoryDelegate>();
 }
+
+class ReanimatedArkTsMessage : public ArkTSMessageHandler {
+    void handleArkTSMessage(const Context &ctx) override {
+        auto rnInstance = ctx.rnInstance.lock();
+        if (rnInstance) {
+            if (ctx.messageName == "REANIMATED_KEY_BOARD_CHANGE") {
+                auto keyboardHeight = ctx.messagePayload["keyboardHeight"].asDouble();
+                auto status = ctx.messagePayload["status"].asInt();
+                rnInstance->getTurboModule<ReanimatedModule>("ReanimatedModule")->callKeyBord(keyboardHeight, status);
+            }
+        }
+    }
+};
+
+std::vector<ArkTSMessageHandler::Shared> ReanimatedPackage::createArkTSMessageHandlers() {
+    return {std::make_shared<ReanimatedArkTsMessage>()};
+}

--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedPackage.h
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedPackage.h
@@ -7,5 +7,7 @@ namespace rnoh {
         ReanimatedPackage(Package::Context ctx) : Package(ctx) {}
     
         std::unique_ptr<TurboModuleFactoryDelegate> createTurboModuleFactoryDelegate() override;
+    
+        std::vector<ArkTSMessageHandler::Shared> createArkTSMessageHandlers() override;
     };
 } // namespace rnoh

--- a/tester/harmony/reanimated/src/main/ets/AnimationManager.ts
+++ b/tester/harmony/reanimated/src/main/ets/AnimationManager.ts
@@ -1,0 +1,57 @@
+export class AnimationManager {
+  private updateValue: number = 0;
+  private animationId: number = 0;
+  private duration: number = 200;
+  private initialValue: number = 0;
+  private targetValue: number = 1;
+  private updateCallback?: (value: number, status: KeyboardState) => void;
+  private status: KeyboardState = KeyboardState.UNKNOWN;
+
+  setUpdateCallback(callback: (value: number, status: KeyboardState) => void): void {
+    this.updateCallback = callback;
+  }
+
+  startAnimation(startValue: number, endValue: number, duration: number): void {
+    if (this.animationId) {
+      this.stopAnimation();
+    }
+    this.initialValue = startValue;
+    this.targetValue = endValue;
+    this.duration = duration;
+    let startTime = Date.now();
+    this.status = endValue > startValue ? KeyboardState.OPENING : KeyboardState.CLOSING;
+
+    this.animationId = setInterval(() => {
+      const elapsedTime = Date.now() - startTime;
+      const progress = Math.min(elapsedTime / this.duration, 1);
+
+      this.updateValue = this.initialValue + progress * (this.targetValue - this.initialValue);
+      if (progress >= 1) {
+        this.status = endValue > startValue ? KeyboardState.OPEN : KeyboardState.CLOSED;
+      }
+      if (this.updateCallback) {
+        this.updateCallback(this.updateValue, this.status);
+      }
+      if (progress >= 1) {
+        this.stopAnimation();
+      }
+    }, 8);
+  }
+
+  // 停止动画
+  stopAnimation(): void {
+    if (this.animationId) {
+      clearInterval(this.animationId);
+      this.animationId = 0;
+    }
+    this.status = KeyboardState.UNKNOWN;
+  }
+}
+
+export enum KeyboardState {
+  UNKNOWN = 0,
+  OPENING = 1,
+  OPEN = 2,
+  CLOSING = 3,
+  CLOSED = 4,
+}

--- a/tester/harmony/reanimated/src/main/ets/ReanimatedModule.ts
+++ b/tester/harmony/reanimated/src/main/ets/ReanimatedModule.ts
@@ -1,9 +1,12 @@
 // import { RNGestureHandlerModule } from '@react-native-oh-tpl/react-native-gesture-handler/ts';
 import { RNOHLogger, Tag, TurboModule, TurboModuleContext } from "@rnoh/react-native-openharmony/ts";
+import { window } from '@kit.ArkUI';
+import { AnimationManager } from './AnimationManager'
 
 export class ReanimatedModule extends TurboModule {
   static NAME = "ReanimatedModule"
   private logger: RNOHLogger
+  private keyBordHeight = 0;
 
   constructor(ctx:  TurboModuleContext) {
     super(ctx);
@@ -12,8 +15,24 @@ export class ReanimatedModule extends TurboModule {
   public setViewProps(tag: Tag, props: Object) {
     this.ctx.descriptorRegistry.setAnimatedRawProps(tag, props);
   }
-  // public setGestureState(handlerTag: Tag, newState: number) {
-  //   const module = this.ctx.rnInstance.getTurboModule<RNGestureHandlerModule>(RNGestureHandlerModule.NAME);
-  //   module.setGestureHandlerState(handlerTag, newState);
-  // }
+
+  public async subscribeKeyBordListeners() {
+    const windowInstance = await window.getLastWindow(this.ctx.uiAbilityContext);
+    windowInstance.on('keyboardHeightChange', async (height) => {
+      let keyBordHeight = this.ctx.getUIContext().px2vp(height);
+      const animationManager = new AnimationManager();
+      animationManager.setUpdateCallback((value, status) => {
+        this.ctx.rnInstance.postMessageToCpp("REANIMATED_KEY_BOARD_CHANGE",
+          { keyboardHeight: value, status: status.valueOf() });
+      });
+      animationManager.startAnimation(this.keyBordHeight, keyBordHeight, 200);
+      this.keyBordHeight = keyBordHeight;
+    })
+  }
+
+  public async unsubscribeKeyBordListeners() {
+    const windowInstance = await window.getLastWindow(this.ctx.uiAbilityContext);
+    windowInstance.off('keyboardHeightChange', (v) => {
+    })
+  }
 }


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- Close: #22 
- feat:新增react-native-reanimated动画库支持useAnimatedKeyboard属性



## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.72.68-CAPI
- DevEco Studio: 5.0.11.100
- OH SDK: HarmonyOS NEXT 5.0.4.150
- ROM: 5.0.0.150(Canary3)
