### PR TITLE
fix:修复原生端引入动画库，引起的偶像崩溃问题，原因：全局的listener监听，导致其他非reanimated组件实现都会走reani…

### DIFF
--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -191,7 +191,9 @@ void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
             if (!nativeReanimatedModule || !taskExecutor || !taskExecutor->isOnTaskThread(TaskThread::MAIN)) {
                 return false;
             }
-
+            if (eventType.empty()) {
+                return false;
+            }
             auto eventType = rawEvent.type;
             auto frameTime = getMillisSinceEpoch();
 
@@ -205,7 +207,9 @@ void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
             } else if (eventType.rfind("topLayout", 0) == 0) { // 针对onLayout事件，不阻断，采用系统处理
                 return false;
             }
-            return nativeReanimatedModule->handleRawEvent(rawEvent, frameTime);
+            //        removed temporarily, event listener mechanism needs to be fixed on RN side
+            //        return nativeReanimatedModule->handleRawEvent(rawEvent, frameTime);
+            return false;
         });
     m_ctx.scheduler->addEventListener(eventListener);
 }


### PR DESCRIPTION
…mated的逻辑，现去除


# Summary

- fix:修复原生端引入动画库，引起的偶像崩溃问题，原因：全局的listener监听，导致其他非reanimated组件实现都会走reanimated的逻辑，现去除
- Close: #31 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码


