### PR TITLE
修复在释放事件处理器时，因访问已销毁对象而导致的空指针解引用与程序崩溃的问题

### DIFF
--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -153,7 +153,7 @@ void NativeReanimatedModule::scheduleOnUI(
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
       rt, worklet, "[Reanimated] Only worklets can be scheduled to run on UI."); 
   auto weakUiWorkletRuntime = std::weak_ptr<WorkletRuntime>(uiWorkletRuntime_);
-  uiScheduler_->scheduleOnUI([weakUiWorkletRuntime, ShareableWorklet] {
+  uiScheduler_->scheduleOnUI([weakUiWorkletRuntime, shareableWorklet] {
         auto uiWorkletRuntime = weakUiWorkletRuntime.lock();
         if (uiWorkletRuntime == nullptr) {
            // Runtime has been destroyed, skip execution

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -152,16 +152,21 @@ void NativeReanimatedModule::scheduleOnUI(
     const jsi::Value &worklet) {
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
       rt, worklet, "[Reanimated] Only worklets can be scheduled to run on UI.");
-  uiScheduler_->scheduleOnUI([=] {
+  uiScheduler_->scheduleOnUI([weakUiWorkletRuntime,ShareableWorklet] {
+        auto uiWorkletRuntime = weakUiWorkletRuntime.lock();
+        if (uiWorkletRuntime == nullptr) {
+           // Runtime has been destroyed, skip execution
+          return;
+        }
 #if JS_RUNTIME_HERMES
     // JSI's scope defined here allows for JSI-objects to be cleared up after
     // each runtime loop. Within these loops we typically create some temporary
     // JSI objects and hence it allows for such objects to be garbage collected
     // much sooner.
     // Apparently the scope API is only supported on Hermes at the moment.
-    const auto scope = jsi::Scope(uiWorkletRuntime_->getJSIRuntime());
+    const auto scope = jsi::Scope(uiWorkletRuntime->getJSIRuntime());
 #endif
-    uiWorkletRuntime_->runGuarded(shareableWorklet);
+    uiWorkletRuntime->runGuarded(shareableWorklet);
   });
 }
 
@@ -241,7 +246,12 @@ void NativeReanimatedModule::unregisterEventHandler(
     const jsi::Value &registrationId) {
   uint64_t id = registrationId.asNumber();
   uiScheduler_->scheduleOnUI(
-      [=] { eventHandlerRegistry_->unregisterEventHandler(id); });
+      [=] { 
+        if (eventHandlerRegistry_ == nullptr) {
+            return;
+        }
+        eventHandlerRegistry_->unregisterEventHandler(id); 
+    });
 }
 
 jsi::Value NativeReanimatedModule::getViewProp(
@@ -258,8 +268,13 @@ jsi::Value NativeReanimatedModule::getViewProp(
   const auto funPtr = std::make_shared<jsi::Function>(
       callback.getObject(rnRuntime).asFunction(rnRuntime));
 
-  uiScheduler_->scheduleOnUI([=]() {
-    jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
+  uiScheduler_->scheduleOnUI([=, weakUiWorkletRuntime]() {
+    auto uiWorkletRuntime = weakUiWorkletRuntime.lock();
+    if (uiWorkletRuntime == nullptr) {
+       // Runtime has been destroyed, skip execution
+      return;
+    }
+    jsi::Runtime &uiRuntime = uiWorkletRuntime->getJSIRuntime();
     const auto propNameValue =
         jsi::String::createFromUtf8(uiRuntime, propNameStr);
     const auto resultValue =
@@ -348,6 +363,10 @@ void NativeReanimatedModule::requestAnimationFrame(
 
 void NativeReanimatedModule::maybeRequestRender() {
   if (!renderRequested_) {
+    if (uiWorkletRuntime_ == nullptr) {
+       // Runtime has been destroyed, skip rendering
+       return;
+    }
     renderRequested_ = true;
     jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
     requestRender_(onRenderCallback_, uiRuntime);
@@ -355,6 +374,11 @@ void NativeReanimatedModule::maybeRequestRender() {
 }
 
 void NativeReanimatedModule::onRender(double timestampMs) {
+  if (uiWorkletRuntime_ == nullptr) {
+     // Runtime has been destroyed, skip rendering
+     frameCallbacks_.clear();
+     return;
+  }
   auto callbacks = std::move(frameCallbacks_);
   frameCallbacks_.clear();
   jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
@@ -435,6 +459,10 @@ bool NativeReanimatedModule::handleEvent(
     const int emitterReactTag,
     const jsi::Value &payload,
     double currentTime) {
+    if (uiWorkletRuntime_ == nullptr) {
+       // Runtime has been destroyed, skip processing
+       return false;
+    }
   eventHandlerRegistry_->processEvent(
       uiWorkletRuntime_, currentTime, eventName, emitterReactTag, payload);
 
@@ -461,6 +489,10 @@ bool NativeReanimatedModule::handleRawEvent(
   if (eventType.rfind("top", 0) == 0) {
     eventType = "on" + eventType.substr(3);
   }
+  if (uiWorkletRuntime_ == nullptr) {
+       // Runtime has been destroyed, skip processing
+       return false;
+    }
   jsi::Runtime &rt = uiWorkletRuntime_->getJSIRuntime();
 #if REACT_NATIVE_MINOR_VERSION >= 73
   const auto &eventPayload = rawEvent.eventPayload;
@@ -502,6 +534,12 @@ void NativeReanimatedModule::performOperations() {
     // nothing to do
     return;
   }
+  if (uiWorkletRuntime_ == nullptr) {
+       // Runtime has been destroyed, skip processing
+        operationsInBatch_.clear();
+        tagsToRemove_.clear();
+       return;
+   }
 
   auto copiedOperationsQueue = std::move(operationsInBatch_);
   operationsInBatch_.clear();

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -151,8 +151,9 @@ void NativeReanimatedModule::scheduleOnUI(
     jsi::Runtime &rt,
     const jsi::Value &worklet) {
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
-      rt, worklet, "[Reanimated] Only worklets can be scheduled to run on UI.");
-  uiScheduler_->scheduleOnUI([weakUiWorkletRuntime,ShareableWorklet] {
+      rt, worklet, "[Reanimated] Only worklets can be scheduled to run on UI."); 
+  auto weakUiWorkletRuntime = std::weak_ptr<WorkletRuntime>(uiWorkletRuntime_);
+  uiScheduler_->scheduleOnUI([weakUiWorkletRuntime, ShareableWorklet] {
         auto uiWorkletRuntime = weakUiWorkletRuntime.lock();
         if (uiWorkletRuntime == nullptr) {
            // Runtime has been destroyed, skip execution

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
@@ -32,7 +32,7 @@ class WorkletRuntime : public jsi::HostObject,
 
   jsi::Runtime &getJSIRuntime() const {
     if (runtime_ == nullptr) {
-        throw std::runtime_error("[Reanimated] WorkletRuntime::getJSIRuntime() called on destroy);
+        throw std::runtime_error("[Reanimated] WorkletRuntime::getJSIRuntime() called on destroy");
     }
     return *runtime_;
   }

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
@@ -8,6 +8,7 @@
 #include "Shareables.h"
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <utility>
@@ -30,6 +31,9 @@ class WorkletRuntime : public jsi::HostObject,
   void installValueUnpacker(const std::string &valueUnpackerCode);
 
   jsi::Runtime &getJSIRuntime() const {
+    if (runtime_ == nullptr) {
+        throw std::runtime_error("[Reanimated] WorkletRuntime::getJSIRuntime() called on destroy);
+    }
     return *runtime_;
   }
 

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -73,7 +73,7 @@ void EventHandlerRegistry::processEvent(
     }
   }
     
-    if (uiWorkletRuntime- == nullptr) {
+    if (uiWorkletRuntime == nullptr) {
         // Runtime has been destroyed, skip processing
         return;
     }

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -72,6 +72,11 @@ void EventHandlerRegistry::processEvent(
       }
     }
   }
+    
+    if (uiWorkletRuntime- == nullptr) {
+        // Runtime has been destroyed, skip processing
+        return;
+    }
 
   jsi::Runtime &rt = uiWorkletRuntime->getJSIRuntime();
   eventPayload.asObject(rt).setProperty(

--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -21,6 +21,9 @@ static double getMillisSinceEpoch() {
 jsi::Value installTurboModule(facebook::jsi::Runtime &rt, react::TurboModule &turboModule,
                               const facebook::jsi::Value *args, size_t count) {
     auto self = static_cast<ReanimatedModule *>(&turboModule);
+    if (self == nullptr) {
+        return facebook::jsi::Value::undefined();
+    }
     self->installTurboModule(rt);
     return facebook::jsi::Value::undefined();
 }

--- a/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/ReanimatedModule.cpp
@@ -194,10 +194,10 @@ void ReanimatedModule::installTurboModule(facebook::jsi::Runtime &rt) {
             if (!nativeReanimatedModule || !taskExecutor || !taskExecutor->isOnTaskThread(TaskThread::MAIN)) {
                 return false;
             }
+            auto eventType = rawEvent.type;
             if (eventType.empty()) {
                 return false;
             }
-            auto eventType = rawEvent.type;
             auto frameTime = getMillisSinceEpoch();
 
             // React Native prefixes event names with "top". If the event name starts with "on", the result is that the


### PR DESCRIPTION
修复空指针解引用导致错误，具体是在释放事件处理器时，可能访问了已销毁的对象，引起闪退问题

Explain the **motivation** for making this change: here are some points to help you:

- What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
- What is the feature? (if applicable)
- How did you implement the solution?
- What areas of the library does it impact?

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
