### PR TITLE
fix:修复Modal与Aimated的组件在同一层级上时，Modal弹窗不生效

### DIFF
--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -37,26 +37,18 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
 
   // ShadowTree not commited by Reanimated, apply updates from PropsRegistry
 
-  auto rootNode = newRootShadowNode->ShadowNode::clone(ShadowNodeFragment{});
-
+  //  auto rootNode = newRootShadowNode->ShadowNode::clone(ShadowNodeFragment{});
+  RootShadowNode::Unshared rootNode = newRootShadowNode;
+  PropsMap propsMap;
   {
     auto lock = propsRegistry_->createLock();
-
     propsRegistry_->for_each(
-        [&](const ShadowNodeFamily &family, const folly::dynamic &props) {
-          auto newRootNode =
-              cloneShadowTreeWithNewProps(rootNode, family, RawProps(props));
-
-          if (newRootNode == nullptr) {
-            // this happens when React removed the component but Reanimated
-            // still tries to animate it, let's skip update for this specific
-            // component
-            return;
-          }
-          rootNode = newRootNode;
-        });
+    [&](const ShadowNodeFamily &family, const folly::dynamic &props) {
+       propsMap[&family] = props;
+    });
   }
-
+    
+  rootNode = cloneShadowTreeWithNewPropsUnmounted(rootNode, propsMap);
   // If the commit comes from React Native then skip one commit from Reanimated
   // since the ShadowTree to be committed by Reanimated may not include the new
   // changes from React Native yet and all changes of animated props will be

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ShadowTreeCloner.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ShadowTreeCloner.cpp
@@ -1,8 +1,128 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#include <ShadowTreeCloner.h>
+#include <react/renderer/core/DynamicPropsUtilities.h>
+
 #include "ShadowTreeCloner.h"
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 
 namespace reanimated {
+
+ChildrenMap calculateChildrenMap(const RootShadowNode &oldRootNode, const PropsMap &propsMap) {
+    ChildrenMap childrenMap;
+    for (auto &[family, _] : propsMap) {
+        const auto ancestors = family->getAncestors(oldRootNode);
+
+        for (auto it = ancestors.rbegin(); it != ancestors.rend(); ++it) {
+            const auto &[parentNode, index] = *it;
+            const auto parentFamily = &parentNode.get().getFamily();
+            auto &affectedChildren = childrenMap[parentFamily];
+
+            int intIndex = static_cast<int>(index);
+            if (affectedChildren.find(intIndex) != affectedChildren.end()) {
+                continue;
+            }
+
+            affectedChildren.insert(intIndex);
+        }
+    }
+    return childrenMap;
+}
+
+ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(const ShadowNode &shadowNode, const ChildrenMap &childrenMap,
+                                                          const PropsMap &propsMap) {
+    const auto &familyRef = shadowNode.getFamily(); // 获取Family的const引用
+    const auto affectedChildrenIt = childrenMap.find(&familyRef);
+
+    PropsMap::const_iterator propsIt;
+
+    propsIt = propsMap.end();
+    for (auto it = propsMap.cbegin(); it != propsMap.cend(); ++it) {
+        if (it->first == &familyRef) {
+            propsIt = it;
+            break;
+        }
+    }
+
+    auto children = shadowNode.getChildren();
+
+    if (affectedChildrenIt != childrenMap.end()) {
+        for (const auto index : affectedChildrenIt->second) {
+            children[index] = cloneShadowTreeWithNewPropsRecursive(*children[index], childrenMap, propsMap);
+        }
+    }
+
+    Props::Shared newProps = nullptr;
+
+    if (propsIt != propsMap.end()) {
+        PropsParserContext propsParserContext{shadowNode.getSurfaceId(), *shadowNode.getContextContainer()};
+        newProps = shadowNode.getProps();
+
+        const folly::dynamic &dynamicProps = propsIt->second;
+        newProps = shadowNode.getComponentDescriptor().cloneProps(propsParserContext, newProps, RawProps(dynamicProps));
+    }
+
+    const auto result = shadowNode.clone({newProps ? newProps : ShadowNodeFragment::propsPlaceholder(),
+                                          std::make_shared<ShadowNode::ListOfShared>(children), shadowNode.getState()});
+
+    return result;
+}
+
+
+ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(ShadowNode::Shared const &oldShadowNode,
+                                                                   const ChildrenMap &childrenMap,
+                                                                   const PropsMap &propsMap) {
+    auto shadowNode = std::const_pointer_cast<ShadowNode>(oldShadowNode);
+    auto layoutableShadowNode = std::dynamic_pointer_cast<LayoutableShadowNode>(shadowNode);
+    if (layoutableShadowNode) {
+        layoutableShadowNode->dirtyLayout();
+    }
+
+    const auto &familyRef = shadowNode->getFamily();
+    const auto affectedChildrenIt = childrenMap.find(&familyRef);
+    PropsMap::const_iterator propsIt;
+
+    propsIt = propsMap.end();
+    for (auto it = propsMap.cbegin(); it != propsMap.cend(); ++it) {
+        if (it->first == &familyRef) {
+            propsIt = it;
+            break;
+        }
+    }
+    auto children = shadowNode->getChildren();
+
+    if (affectedChildrenIt != childrenMap.end()) {
+        for (const auto index : affectedChildrenIt->second) {
+            auto clone = cloneShadowTreeWithNewPropsUnmountedRecursive(children[index], childrenMap, propsMap);
+            if (clone != children[index]) {
+                shadowNode->replaceChild(*children[index], clone, index);
+            }
+        }
+    }
+
+    Props::Shared newProps = nullptr;
+
+    if (propsIt != propsMap.end()) {
+        PropsParserContext propsParserContext{shadowNode->getSurfaceId(), *shadowNode->getContextContainer()};
+        newProps = shadowNode->getProps();
+
+        const folly::dynamic &dynamicProps = propsIt->second;
+        newProps =
+            shadowNode->getComponentDescriptor().cloneProps(propsParserContext, newProps, RawProps(dynamicProps));
+    }
+    
+    if (newProps && !shadowNode->getSealed()) {
+        auto &props = shadowNode->getProps();
+        auto &mutableProps = const_cast<Props::Shared &>(props);
+        mutableProps = newProps;
+        auto layoutableShadowNode = static_pointer_cast<YogaLayoutableShadowNode>(shadowNode);
+        layoutableShadowNode->updateYogaProps();
+    }
+
+    return shadowNode;
+}
 
 ShadowNode::Unshared cloneShadowTreeWithNewProps(
     const ShadowNode::Shared &oldRootNode,
@@ -22,10 +142,10 @@ ShadowNode::Unshared cloneShadowTreeWithNewProps(
   PropsParserContext propsParserContext{
       source->getSurfaceId(), *source->getContextContainer()};
   const auto props = source->getComponentDescriptor().cloneProps(
-      propsParserContext, source->getProps(), rawProps);
+      propsParserContext, source->getProps(), std::move(rawProps));
 
   auto newChildNode = source->clone({/* .props = */ props, ShadowNodeFragment::childrenPlaceholder(), source->getState()});
-    
+
   for (auto it = ancestors.rbegin(); it != ancestors.rend(); ++it) {
     auto &parentNode = it->first.get();
     auto childIndex = it->second;
@@ -56,6 +176,18 @@ ShadowNode::Unshared cloneShadowTreeWithNewProps(
   }
 
   return std::const_pointer_cast<ShadowNode>(newChildNode);
+}
+
+RootShadowNode::Unshared cloneShadowTreeWithNewPropsUnmounted(
+    RootShadowNode::Unshared const &oldRootNode,
+    const PropsMap &propsMap) {
+  auto childrenMap = calculateChildrenMap(*oldRootNode, propsMap);
+
+  // This cast is safe, because this function returns a clone
+  // of the oldRootNode, which is an instance of RootShadowNode
+  return std::static_pointer_cast<RootShadowNode>(
+      cloneShadowTreeWithNewPropsUnmountedRecursive(
+          oldRootNode, childrenMap, propsMap));
 }
 
 } // namespace reanimated

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ShadowTreeCloner.h
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/Fabric/ShadowTreeCloner.h
@@ -12,10 +12,18 @@ using namespace react;
 
 namespace reanimated {
 
+using PropsMap = std::unordered_map<const facebook::react::ShadowNodeFamily*, folly::dynamic>;
+using ChildrenMap =
+    std::unordered_map<const ShadowNodeFamily *, std::unordered_set<int>>;
+
 ShadowNode::Unshared cloneShadowTreeWithNewProps(
     const ShadowNode::Shared &oldRootNode,
     const ShadowNodeFamily &family,
     RawProps &&rawProps);
+
+RootShadowNode::Unshared cloneShadowTreeWithNewPropsUnmounted(
+    RootShadowNode::Unshared const &oldRootShadowNode,
+    const PropsMap &propsMap);
 
 } // namespace reanimated
 

--- a/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
+++ b/tester/harmony/reanimated/src/main/cpp/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
@@ -17,15 +17,25 @@ WorkletRuntime::WorkletRuntime(
   WorkletRuntimeDecorator::decorate(rt, name, jsScheduler);
 }
 
-void WorkletRuntime::installValueUnpacker(
-    const std::string &valueUnpackerCode) {
-  jsi::Runtime &rt = *runtime_;
-  auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
-      "(" + valueUnpackerCode + "\n)");
-  auto valueUnpacker = rt.evaluateJavaScript(codeBuffer, "installValueUnpacker")
-                           .asObject(rt)
-                           .asFunction(rt);
-  rt.global().setProperty(rt, "__valueUnpacker", valueUnpacker);
+void WorkletRuntime::installValueUnpacker(const std::string &valueUnpackerCode) {
+    if (valueUnpackerCode.empty() || !runtime_) {
+        return;
+    }
+    jsi::Runtime &rt = *runtime_;
+    auto codeBuffer = std::make_shared<const jsi::StringBuffer>("(" + valueUnpackerCode + "\n)");
+    if (!codeBuffer) { //防止极限条件下没有分配到内存
+        return;
+    }
+    auto valueUnpacker = rt.evaluateJavaScript(codeBuffer, "installValueUnpacker");
+    if (!valueUnpacker.isObject()) {
+        return;
+    }
+    auto valueUnpackerObject = valueUnpacker.asObject(rt);
+    if (!valueUnpackerObject.isFunction(rt)) {
+        return;
+    }
+    auto valueUnpackerFun =  valueUnpackerObject.asFunction(rt);
+    rt.global().setProperty(rt, "__valueUnpacker", valueUnpackerFun);
 }
 
 jsi::Value WorkletRuntime::get(


### PR DESCRIPTION
# Summary

- fix:修复Modal与Aimated的组件在同一层级上时，Modal弹窗不生效
- Closed: #37 


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)